### PR TITLE
Customize binning preview scatter markers

### DIFF
--- a/lcviz/marks.py
+++ b/lcviz/marks.py
@@ -5,6 +5,8 @@ from lcviz.viewers import PhaseScatterView
 
 __all__ = ['LivePreviewTrend', 'LivePreviewFlattened', 'LivePreviewBinning']
 
+lcviz_preview_color = "#46C089"
+
 
 class WithoutPhaseSupport:
     def update_ty(self, times, y):
@@ -46,4 +48,6 @@ class LivePreviewFlattened(PluginScatter, WithPhaseSupport):
 class LivePreviewBinning(PluginScatter, WithPhaseSupport):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('default_size', 16)
+        kwargs.setdefault('colors', [lcviz_preview_color])
+        kwargs.setdefault('marker', 'square')
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Submitting this PR to your binning PR (https://github.com/spacetelescope/lcviz/pull/28) so that we can just merge it in if https://github.com/spacetelescope/jdaviz/pull/2453 gets merged+released in time.

This PR makes live-preview scatter plots more visible in LCviz, specifically for the Binning plugin, by changing the default LCviz binning live-preview color to a light green that's not in the color cycle, and making the markers squares:
<img width="1412" alt="Screen Shot 2023-09-13 at 10 55 50" src="https://github.com/kecnry/lcviz/assets/3497584/6190e8e5-5729-4d87-a6cb-72cd7bce2c36">

Final color options are up for debate of course, happy for other suggestions. I chose this green by [using a web tool to generate color palettes based on the default jdaviz blue](https://mycolor.space/?hex=%23007BA1&sub=1).