### PR TITLE
migrate temporary disabling previews upstream

### DIFF
--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -1,5 +1,3 @@
-import numpy as np
-from time import time
 from astropy.time import Time
 from traitlets import Bool, Float, observe
 from glue.config import data_translator
@@ -10,7 +8,7 @@ from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         DatasetSelectMixin, AddResultsMixin,
                                         skip_if_no_updates_since_last_active,
-                                        with_spinner)
+                                        with_spinner, with_temp_disable)
 from jdaviz.core.user_api import PluginUserApi
 
 from lcviz.components import FluxColumnSelectMixin
@@ -53,9 +51,6 @@ class Binning(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin,
 
     n_bins = IntHandleEmpty(100).tag(sync=True)
     bin_enabled = Bool(True).tag(sync=True)
-
-    last_live_time = Float(0).tag(sync=True)
-    previews_temp_disable = Bool(False).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -157,19 +152,15 @@ class Binning(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin,
 
     @observe('flux_column_selected', 'dataset_selected',
              'ephemeris_selected',
-             'n_bins', 'previews_temp_disable')
+             'n_bins', 'previews_temp_disabled')
     @skip_if_no_updates_since_last_active()
+    @with_temp_disable(timeout=0.3)
     def _live_update(self, event={}):
         self.bin_enabled = self.n_bins != '' and self.n_bins > 0
 
         if not self.show_live_preview or not self.is_active or not self.bin_enabled:
             self._clear_marks()
             return
-
-        if self.previews_temp_disable:
-            return
-
-        start = time()
 
         if event.get('name', '') not in ('is_active', 'show_live_preview'):
             # mark visibility hasn't been handled yet
@@ -206,10 +197,6 @@ class Binning(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin,
             else:
                 mark.times = []
                 mark.update_xy(times, lc.flux.value)
-
-        self.last_live_time = np.round(time() - start, 2)
-        if self.last_live_time > 0.3:
-            self.previews_temp_disable = True
 
     def _on_ephemeris_update(self, msg):
         if not self.show_live_preview or not self.is_active:

--- a/lcviz/plugins/binning/binning.vue
+++ b/lcviz/plugins/binning/binning.vue
@@ -57,23 +57,11 @@
       </v-text-field>
     </v-row>
 
-    <v-alert v-if="previews_temp_disable && show_live_preview" type='warning' style="margin-left: -12px; margin-right: -12px">
-      Live-updating is temporarily disabled (last update took {{last_live_time}}s)
-      <v-row justify='center'>
-        <j-tooltip tooltipcontent='hide live preview (can be re-enabled from the settings section in the plugin).' span_style="width: 100%">
-          <v-btn style='width: 100%' @click="show_live_preview = false">
-            disable previews
-          </v-btn>
-        </j-tooltip>
-      </v-row>
-      <v-row justify='center'>
-        <j-tooltip tooltipcontent='manually update live-previews based on current plugin inputs.' span_style="width: 100%">
-          <v-btn style='width: 100%' @click="previews_temp_disable = false">
-            update preview
-          </v-btn>
-        </j-tooltip>
-      </v-row>
-    </v-alert>
+    <plugin-previews-temp-disabled
+      :previews_temp_disabled.sync="previews_temp_disabled"
+      :previews_last_time="previews_last_time"
+      :show_live_preview.sync="show_live_preview"
+    />
 
     <plugin-add-results
       :label.sync="results_label"

--- a/lcviz/plugins/flatten/flatten.vue
+++ b/lcviz/plugins/flatten/flatten.vue
@@ -138,23 +138,12 @@
       hint="Label for flux column."
     ></plugin-auto-label>
 
-    <v-alert v-if="previews_temp_disable && (show_live_preview || show_trend_preview)" type='warning' style="margin-left: -12px; margin-right: -12px">
-      Live-updating is temporarily disabled (last update took {{last_live_time}}s)
-      <v-row justify='center'>
-        <j-tooltip tooltipcontent='hide live trend and flattened previews (can be re-enabled from the settings section in the plugin).' span_style="width: 100%">
-          <v-btn style='width: 100%' @click="() => {show_live_preview = false; show_trend_preview = false}">
-            disable previews
-          </v-btn>
-        </j-tooltip>
-      </v-row>
-      <v-row justify='center'>
-        <j-tooltip tooltipcontent='manually update live-previews based on current plugin inputs.' span_style="width: 100%">
-          <v-btn style='width: 100%' @click="previews_temp_disable = false">
-            update preview
-          </v-btn>
-        </j-tooltip>
-      </v-row>
-    </v-alert>
+    <plugin-previews-temp-disabled
+      :previews_temp_disabled.sync="previews_temp_disabled"
+      :previews_last_time="previews_last_time"
+      :show_live_preview="show_live_preview || show_trend_preview"
+      @disable_previews="() => {show_live_preview=false; show_trend_preview=false}"
+    />
 
     <v-row justify="end">
       <j-tooltip tooltipcontent="Flatten and select the new column as the adopted flux column">


### PR DESCRIPTION
https://github.com/spacetelescope/jdaviz/pull/2733 migrates lcviz functionality for disabling live-previews upstream.  This PR makes use of the upstream implementation in lcviz, _without_ changing any behavior in lcviz.