### PR TITLE
don't open data menu when populating phase viewer

### DIFF
--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -294,7 +294,8 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
         phase_viewer_id = self._generate_phase_viewer_id(ephem_component)
         # TODO: stack horizontally by default?
         self.app._on_new_viewer(NewViewerMessage(PhaseScatterView, data=None, sender=self.app),
-                                vid=phase_viewer_id, name=phase_viewer_id)
+                                vid=phase_viewer_id, name=phase_viewer_id,
+                                open_data_menu_if_empty=False)
 
         # access new viewer, set bookkeeping for ephemeris component
         pv = self.app.get_viewer(phase_viewer_id)


### PR DESCRIPTION
if https://github.com/spacetelescope/jdaviz/pull/2742 is merged, we should include this to avoid opening the data menu when creating populated phase viewers